### PR TITLE
Allow passing in the storage layer as a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 This plugin aims to provide a basic voicemail implementation, complete with a voicemail system that allows user to listen to messages and manage them. It is currently only compatible with Asterisk, and you will need to provide the audio files and their path in the configuration. The configuration also contains many other options.
 
-## Storage
-
-Mailbox metadata is stored in a PStore hash on disk for easy drop-in functionality.
-To implement your owm storage layer, look at the StorageMain class for method signatures.
-
 ## Usage
 
 Every mailbox has an id and PIN that can be provisioned using a pry console.
@@ -21,6 +16,25 @@ To allow access by users to the mailboxes, `invoke MailboxController`. You will 
 ```ruby
   # inside a CallController method
   invoke Voicemail::MailboxController, mailbox: mailbox_id
+```
+
+## Storage
+
+Mailbox metadata is stored in a PStore hash on disk for easy drop-in functionality.
+To implement your owm storage layer, look at the StorageMain class for method signatures.
+
+You can set the storage layer globally in configuration.
+```ruby
+  config.voicemail.storage.storage_class = StorageWidget
+```
+
+Alternatively, you can pass in a storage layer dynamically when invoking the controller.
+```ruby
+  if customer.voicemail_version == VERSION_ONE
+    invoke Voicemail::VoicemailController, mailbox: customer.mailbox_id, storage: VersionOneStorage.new
+  elsif customer.voicemail_version == VERSION_TWO
+    invoke Voicemail::VoicemailController, mailbox: customer.mailbox_id, storage: VersionTwoStorage.new
+  # etc.
 ```
 
 ## Author

--- a/lib/voicemail/application_controller.rb
+++ b/lib/voicemail/application_controller.rb
@@ -7,7 +7,7 @@ module Voicemail
     private
 
     def storage
-      Storage.instance
+      metadata[:storage] || Storage.instance
     end
 
     def config

--- a/spec/support/voicemail_controller_spec_helper.rb
+++ b/spec/support/voicemail_controller_spec_helper.rb
@@ -3,9 +3,6 @@ module VoicemailControllerSpecHelper
     test_case.let(:from)    { "sip:user@server.com" }
     test_case.let(:call)    { flexmock 'Call', from: from }
     test_case.let(:config)  { Voicemail::Plugin.config }
-    test_case.let(:metadata) do
-      { :mailbox => '100' }
-    end
     test_case.let(:greeting_message) { nil }
     test_case.let(:mailbox) do
       {
@@ -17,12 +14,14 @@ module VoicemailControllerSpecHelper
       }
     end
     test_case.let(:storage_instance) { flexmock 'StorageInstance' }
+    test_case.let(:metadata) do
+      { :mailbox => '100', :storage => storage_instance }
+    end
 
     test_case.subject(:controller) { flexmock test_case.described_class.new(call, metadata) }
 
     test_case.before(:each) do
       storage_instance.should_receive(:get_mailbox).with(metadata[:mailbox]).and_return(mailbox)
-      flexmock(Voicemail::Storage).should_receive(:instance).and_return(storage_instance)
     end
   end
 


### PR DESCRIPTION
Short and sweet:  Let you pass in a storage layer.

It defaults to using the storage layer set in configuration if you don't pass anything in.  This can be unhelpful, since you silently get an unexpected storage layer if you forget to include the key on one invocation, but it maintains backwards compatibility.
