### PR TITLE
Feature/add i18n

### DIFF
--- a/lib/voicemail.rb
+++ b/lib/voicemail.rb
@@ -1,7 +1,10 @@
+require 'adhearsion'
+
 module Voicemail; end
 require "voicemail/version"
 require "voicemail/storage_pstore"
 require "voicemail/storage"
+require "voicemail/localization_loader"
 require "voicemail/application_controller"
 require "voicemail/voicemail_controller"
 require "voicemail/mailbox_controller"

--- a/lib/voicemail/localization_loader.rb
+++ b/lib/voicemail/localization_loader.rb
@@ -1,0 +1,28 @@
+module Voicemail::LocalizationLoader
+
+  def self.replace_config
+    translation_keys.each { |key, value| override_config key, value }
+  end
+
+  #
+  #This method scans the keys in the template en.yml - it doesn't use any values,
+  #it just sets up methods to call i18n.translate later
+  #
+  def self.override_config(key, value)
+    if value.class == String
+      Voicemail::Plugin.config[key.to_sym] = Proc.new { I18n.t "voicemail.#{key}" }
+    else
+      value.keys.each do |k, v|
+        Voicemail::Plugin.config[key.to_sym][k.to_sym] = Proc.new { I18n.t("voicemail.#{key}.#{k}") }
+      end
+    end
+  end
+
+  def self.translation_keys
+    YAML.load(File.open("#{current_path}/../../templates/en.yml"))['en']['voicemail']
+  end
+
+  def self.current_path
+    File.expand_path File.dirname(__FILE__)
+  end
+end

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -2,18 +2,24 @@ module Voicemail
   class Plugin < Adhearsion::Plugin
 
     init :voicemail do
-      logger.info "Voicemail has been loaded"
+      if config.use_i18n
+        LocalizationLoader.replace_config
+        logger.info "Voicemail has been loaded with i18n support"
+      else
+        logger.info "Voicemail has been loaded"
+      end
     end
 
     config :voicemail do
-      default_greeting "You have reached voicemail", desc: "What to use to greet users"
-      mailbox_not_found "Mailbox not found", desc: "Message to use for a missing mailbox"
+      use_i18n false, desc: "Whether to use i18n for voice prompts"
+      force_183 false, desc: "Only #answer if the mailbox is found"
       prompt_timeout 5, desc: "Timeout for the various prompts, in seconds"
       menu_timeout 15.seconds, desc: "Timeout for all menus"
       menu_tries 3, desc: "Tries to get matching input for all menus"
       datetime_format "Q 'digits/at' IMp", desc: "Fromat to use for message date and time TTS"
 
-      force_183 false, desc: "Only #answer if the mailbox is found"
+      default_greeting "You have reached voicemail", desc: "What to use to greet users"
+      mailbox_not_found "Mailbox not found", desc: "Message to use for a missing mailbox"
 
       desc "Voicemail recording options"
       recording {

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -89,8 +89,17 @@ module Voicemail
         task :info do
           STDOUT.puts "Voicemail plugin v. #{VERSION}"
         end
+
+        desc "Copy an initial translation file (en) to your adhearsion project (ahn_root/config/locales/en.yml)"
+        task :i18n_init do
+          current_path  = File.expand_path(File.dirname(__FILE__))
+          template_file = "#{current_path}/../../templates/en.yml"
+          new_location  = "#{Dir.pwd}/config/locales/"
+
+          FileUtils.mkdir_p(new_location) unless File.directory?(new_location)
+          FileUtils.copy template_file, "#{new_location}en.yml"
+        end
       end
     end
-
   end
 end

--- a/spec/voicemail/localization_loader_spec.rb
+++ b/spec/voicemail/localization_loader_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe Voicemail::LocalizationLoader do
+
+  before { @old_config = Voicemail::Plugin.config.default_greeting }
+  after  { Voicemail::Plugin.config.default_greeting = @old_config }
+
+  describe ".replace_config" do
+    let(:mock_hash) { {'en' => {'voicemail' => {'default_greeting' => 'foo'}}} }
+
+    before do
+      flexmock(YAML).should_receive(:load).and_return mock_hash
+      flexmock(I18n).should_receive(:t).and_return "bar"
+    end
+
+    it "changes the values to i18n" do
+      subject.replace_config
+      Voicemail::Plugin.config.default_greeting.should == "bar"
+    end
+  end
+end

--- a/templates/en.yml
+++ b/templates/en.yml
@@ -1,0 +1,36 @@
+en:
+  voicemail:
+    default_greeting: "You have reached voicemail"
+    mailbox_not_found: "Mailbox not found"
+
+    mailbox:
+      greeting_message: "Welcome to the mailbox system."
+      please_enter_pin: "Please enter your PIN."
+      pin_wrong: "The PIN you entered does not match. Please try again."
+      could_not_auth: "We are sorry, the system could not authenticate you"
+      number_before: "You have "
+      number_after: " new messages"
+      menu_greeting: "Press 1 to listen to new messages, 2 to change your greeting, 3 to change your PIN"
+      menu_timeout_message: "Please enter a digit for the menu"
+      menu_invalid_message: "Please enter valid input"
+      menu_failure_message: "Sorry, unable to understand your input."
+
+    set_greeting:
+      prompt: "Press 1 to listen to your current greeting, 2 to record a new greeting, 9 to return to the main menu"
+      before_record: "Please speak after the beep. The prompt will be played back after."
+      after_record: "Press 1 to save your new greeting, 2 to discard it, 9 to go back to the menu"
+      no_personal_greeting: "You do not currently have a personalized greeting."
+
+    set_pin:
+      menu: "Press 1 to change your current PIN, or 9 to go back to the main menu"
+      prompt: "Enter your new PIN of at least four digits followed by the pound sign"
+      repeat_prompt: "Please enter your new PIN again, followed by the pound sign"
+      pin_error: "Please enter at least four digits followed by the pound sign."
+      match_error: "The two entered PINs don't match, please try again."
+      change_ok: "Your PIN has been successfully changed"
+
+    messages:
+      menu: "Press 1 to archive the message and go to the next, press 5 to delete the message and go to the next, press 7 to hear the message again, press 9 for the main menu"
+      no_new_messages: "There are no new messages"
+      message_received_on: "Message received on "
+      from: " from "


### PR DESCRIPTION
Initial i18n support.  This will allow you to replace the greetings set in the config with i18n translations.  Out of the box, this should allow you to configure dozens of languages with the same functionality as we currently have. (Well, mostly out of the box - you need to add an initializer to your project like this:

``` ruby
I18n.load_path += Dir[File.join(config.platform.root, 'config', 'locales', '*.{rb,yml}').to_s]
I18n.default_locale = :en
```

Which I'll need to add to the docs... of course, if you're looking to enable i18n support in a plugin, you probably already have it in the rest of the app.
#### But wait!

here comes the kicker for moving forward...

Instead of just swapping out messages, I'd like to make it even more configurable. For example, here's the part of the code that currently plays the number of new messages you have.

``` ruby
play config.mailbox.number_before
play_numeric number
play config.mailbox.number_after
```

Now we'll be able to have that in different languages... but what if we want that more changable?  Maybe some users want the existing functionality, but other users would rather have the whole thing rendered as one TTS through i18n `"You have %count new message(s)"`.    

I think we should think about how much customizability we want to add here...  I think at the very least we need to be able to make it so we can pass a count in the number_after, so the i18n can handle pluralization.

Right now the `number_after` default is "`new messages`", and i18n or not, there's no way to change that to change it to `"new message."` if they have one message.  

Perhaps this is a separate issue, but I think fixing the pluralization goes right along with allowing for i18n support... 

Anyways, curious as to your thoughts @benlangfeld @bklang, as i18n needs to be added to adhearison core anyways...

One other possibility is just to make i18n hardcoded instead of an option - adhearsion loads activesupport which loads i18n, so the gem's there anyways... 
