### PR TITLE
Prompt returns vs. hangup, and guards

### DIFF
--- a/lib/voicemail/call_controllers/mailbox_cleaner_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_cleaner_controller.rb
@@ -20,9 +20,15 @@ module Voicemail
    
     def erase_all(type)
       method = "next_#{type}_message"
-   
-      while message = storage.send(method, mailbox[:id])
+
+      messages_count = storage.send "count_#{type}_messages", mailbox[:id]   
+      
+      messages_count.times do
+        message = storage.send(method, mailbox[:id])
         storage.delete_message mailbox[:id], message[:id]
+        
+        all_messages_deleted = metadata[:new_or_saved].to_s == "new" ? config.mailbox.all_new_messages_deleted : config.mailbox.all_saved_messages_deleted
+        play all_messages_deleted
       end
 
       main_menu

--- a/lib/voicemail/call_controllers/mailbox_cleaner_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_cleaner_controller.rb
@@ -24,6 +24,8 @@ module Voicemail
       while message = storage.send(method, mailbox[:id])
         storage.delete_message mailbox[:id], message[:id]
       end
+
+      main_menu
     end
   end
 end

--- a/lib/voicemail/call_controllers/mailbox_play_message_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_play_message_controller.rb
@@ -37,7 +37,7 @@ module Voicemail
 
         failure do
           play config.mailbox.menu_failure_message
-          hangup
+          main_menu
         end
       end
     end

--- a/lib/voicemail/call_controllers/mailbox_set_greeting_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_set_greeting_controller.rb
@@ -24,7 +24,7 @@ module Voicemail
 
         failure do
           play config.mailbox.menu_failure_message
-          hangup
+          main_menu
         end
       end
     end
@@ -63,7 +63,7 @@ module Voicemail
 
         failure do
           play config.mailbox.menu_failure_message
-          hangup
+          section_menu
         end
       end
     end
@@ -83,7 +83,7 @@ module Voicemail
 
         failure do
           play config.mailbox.menu_failure_message
-          hangup
+          section_menu
         end
       end
     end

--- a/lib/voicemail/call_controllers/mailbox_set_pin_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_set_pin_controller.rb
@@ -20,7 +20,7 @@ module Voicemail
 
         failure do
           play config.mailbox.menu_failure_message
-          hangup
+          main_menu
         end
       end
     end

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -58,7 +58,7 @@ module Voicemail
         clear_saved_messages "Are you sure you want to permanently erase all saved messages? Press 1 to delete, or any other key to cancel", desc: "Saved message clearing confirmation"
         no_messages_deleted "Your messages will not be deleted. Returning to main menu."
         all_new_messages_deleted "All of your new messages have been successfully deleted."
-        all_saved_messages_deleted "All of your saved messages have bee successfully deleted."
+        all_saved_messages_deleted "All of your saved messages have been successfully deleted."
       }
 
       desc "Set greeting configuration"

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -57,6 +57,8 @@ module Voicemail
         clear_new_messages "Are you sure you want to permanently erase all new messages? Press 1 to delete, or any other key to cancel", desc: "New message clearing confirmation"
         clear_saved_messages "Are you sure you want to permanently erase all saved messages? Press 1 to delete, or any other key to cancel", desc: "Saved message clearing confirmation"
         no_messages_deleted "Your messages will not be deleted. Returning to main menu."
+        all_new_messages_deleted "All of your new messages have been successfully deleted."
+        all_saved_messages_deleted "All of your saved messages have bee successfully deleted."
       }
 
       desc "Set greeting configuration"

--- a/templates/en.yml
+++ b/templates/en.yml
@@ -17,14 +17,14 @@ en:
     '0': "zero "
 
   voicemail:
-    default_greeting: "You have reached voicemail"
+    default_greeting: "You have reached Voicemail"
     mailbox_not_found: "Mailbox not found"
 
     mailbox:
       greeting_message: "Welcome to the mailbox system."
       please_enter_pin: "Please enter your PIN."
       pin_wrong: "The PIN you entered does not match. Please try again."
-      could_not_auth: "We are sorry, the system could not authenticate you"
+      could_not_auth: "We are sorry, the system could not authenticate you."
       number_before: "You have "
       number_after: " new messages"
       number_after_saved: " saved messages"
@@ -34,34 +34,35 @@ en:
       x_saved_messages:
         one: "You have one saved message. "
         other: "You have %{count} saved messages. "
-      menu_greeting: "Press 1 to listen to new messages, 2 to change your greeting, 3 to change your PIN"
-      menu_timeout_message: "Please enter a digit for the menu"
-      menu_invalid_message: "Please enter valid input"
+      menu_greeting: "Press 1 to listen to new messages, 2 to change your greeting, 3 to change your PIN."
+      menu_timeout_message: "Please enter a digit for the menu."
+      menu_invalid_message: "Please enter valid input."
       menu_failure_message: "Sorry, unable to understand your input."
 
     after_record: "Press 1 to save your voicemail.  Press 2 to rerecord."
 
     set_greeting:
-      prompt: "Press 1 to listen to your current greeting, 2 to record a new greeting, 9 to return to the main menu"
+      prompt: "Press 1 to listen to your current greeting, 2 to record a new greeting, 9 to return to the main menu."
       before_record: "Please speak after the beep. The prompt will be played back after."
-      after_record: "Press 1 to save your new greeting, 2 to discard it, 9 to go back to the menu"
+      after_record: "Press 1 to save your new greeting, 2 to discard it, 9 to go back to the menu."
       no_personal_greeting: "You do not currently have a personalized greeting."
 
     set_pin:
-      menu: "Press 1 to change your current PIN, or 9 to go back to the main menu"
-      prompt: "Enter your new PIN of at least four digits followed by the pound sign"
-      repeat_prompt: "Please enter your new PIN again, followed by the pound sign"
+      menu: "Press 1 to change your current PIN, or 9 to go back to the main menu."
+      prompt: "Enter your new PIN of at least four digits followed by the pound sign."
+      repeat_prompt: "Please enter your new PIN again, followed by the pound sign."
       pin_error: "Please enter at least four digits followed by the pound sign."
       match_error: "The two entered PINs don't match, please try again."
-      change_ok: "Your PIN has been successfully changed"
+      change_ok: "Your PIN has been successfully changed."
 
     messages:
       menu_new: "Press 1 to archive the message and go to the next, press 5 to delete the message and go to the next, press 7 to hear the message again, press 9 for the main menu"
       menu_saved: "Press 1 to unarchive the message and go to the next, press 5 to delete the message and go to the next, press 7 to hear the message again, press 9 for the main menu"
-      no_new_messages: "There are no new messages"
-      no_saved_messages: "There are no saved messages"
+      no_new_messages: "There are no new messages."
+      no_saved_messages: "There are no saved messages."
       message_received_on: "Message received on "
       from: " from "
       message_received_on_x: "Message received on %{received_on}. "
       message_received_from_x: "Message received from %{from}. "
-
+      all_new_messages_deleted: "All of your new messages have been deleted."
+      all_saved_messages_deleted: "All of your saved messages have been deleted."


### PR DESCRIPTION
There are a number of places where we are hanging up on a caller if they fail a menu structure. In my mind, this should only happen on the main_menu -- any section_menu (or lower tier) should fall back to the previous higher tier. 

Only main_menu should be able to issue the final `hangup.`
