### PR TITLE
Fix for not entering a pin while setting your pin code

### DIFF
--- a/lib/voicemail/call_controllers/mailbox_set_pin_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_set_pin_controller.rb
@@ -29,7 +29,7 @@ module Voicemail
       pin = ask config.set_pin.prompt, terminator: "#", timeout: 5
       repeat_pin = ask config.set_pin.repeat_prompt, terminator: "#", timeout: 5
 
-      if pin.to_s.size < config.set_pin.pin_minimum_digits
+      if pin.to_s.nil? || pin.to_s.size < config.set_pin.pin_minimum_digits
         play config.set_pin.pin_error
         set_pin
       elsif pin.to_s != repeat_pin.to_s


### PR DESCRIPTION
In the current codebase, https://github.com/adhearsion/voicemail/blob/develop/lib/voicemail/call_controllers/mailbox_set_pin_controller.rb#L32 will explode with an `undefined method`size' for nil:NilClass` if a user hits the terminator twice without entering any other DTMF.

This fixes that.
