### PR TITLE
hotfix/1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # develop
 
+# v1.1.2 - 2014-06-23
+  * BUG - Re-arrange on_end callback so that recordings are saved if hangup occurs during a recording
+
 # v1.1.1 - 2014-06-10
   * BUG - Remove implicit dependency on loading activesupport
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-#develop
+# develop
+
+# v1.1.1 - 2014-06-10
+  * BUG - Remove implicit dependency on loading activesupport
+
+# v1.1.0 - 2014-05-07
   * CHANGE - Menu intros are one message, making them skippable.
   * FEATURE - Personalized voicemail greetings can be deleted
   * FEATURE - Add message to play after recording a voicemail is complete
@@ -7,7 +12,7 @@
   * FEATURE - Allow messages to be skipped
   * BUG - Resolve issue where caller presses the pound key twice in succession
 
-#v1.0.0 - 2014-01-02
+# v1.0.0 - 2014-01-02
   * FEATURE - Optional per-mailbox override of default recording hash
   * FEATURE - Optional rerecording of voicemail messages
   * FEATURE - I18n numeric methods

--- a/lib/voicemail/call_controllers/voicemail_controller.rb
+++ b/lib/voicemail/call_controllers/voicemail_controller.rb
@@ -25,13 +25,14 @@ module Voicemail
     end
 
     def record_message
+      ensure_message_saved_if_hangup
+
       @recording = record record_options
 
       config.allow_rerecording ? recording_menu : save_recording
     end
 
     def recording_menu
-      ensure_message_saved_if_hangup
       menu recording_url, config.after_record, tries: 3, timeout: 10 do
         match('1') { save_recording }
         match('2') { record_message }
@@ -46,7 +47,7 @@ module Voicemail
 
     def ensure_message_saved_if_hangup
       call.on_end do
-        save_recording unless @saved
+        save_recording if recording && !@saved
       end
     end
 

--- a/lib/voicemail/matcher.rb
+++ b/lib/voicemail/matcher.rb
@@ -4,8 +4,8 @@
 module Voicemail
   class Matcher
     def initialize(entered, actual)
-      @entered = entered.try :to_s
-      @actual  = actual.try :to_s
+      @entered = entered.to_s
+      @actual  = actual.to_s
     end
 
     def matches?

--- a/lib/voicemail/plugin.rb
+++ b/lib/voicemail/plugin.rb
@@ -13,7 +13,7 @@ module Voicemail
     config :voicemail do
       use_i18n false, desc: "Whether to use i18n for voice prompts"
       prompt_timeout 5, desc: "Timeout for the various prompts, in seconds"
-      menu_timeout 15.seconds, desc: "Timeout for all menus"
+      menu_timeout 15, desc: "Timeout for all menus"
       menu_tries 3, desc: "Tries to get matching input for all menus"
       datetime_format "Q 'digits/at' IMp", desc: "Format to use for message date and time formatting"
 

--- a/lib/voicemail/version.rb
+++ b/lib/voicemail/version.rb
@@ -1,3 +1,3 @@
 module Voicemail
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/voicemail/version.rb
+++ b/lib/voicemail/version.rb
@@ -1,3 +1,3 @@
 module Voicemail
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/spec/voicemail/call_controllers/voicemail_controller_spec.rb
+++ b/spec/voicemail/call_controllers/voicemail_controller_spec.rb
@@ -76,6 +76,7 @@ describe Voicemail::VoicemailController do
         before { config.allow_rerecording = false }
 
         it "saves the recording" do
+          call.should_receive :on_end
           recording_component.should_receive("complete_event.recording").and_return recording_object
           subject.should_receive(:record).with(config.recording.to_hash).and_return recording_component
           storage_instance.should_receive(:save_recording).with mailbox[:id], call.from, recording_object


### PR DESCRIPTION
Quick hotfix to guarantee that the `on_end` callback is actually used. In the current configuration, Adhearsion can exit without ever seeing the call to setup `on_end`, thereby leaving voicemails to be delivered to nobody except the recording directory.
