### PR TITLE
Add `new_or_saved` param to listen_to_new_messages metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * BUG - Listening to new messages needs to set the `new_or_saved` metadata. Otherwise, after visiting saved messages, the status is always `:saved`
   * FEATURE - Refactor voicemail storage (backward incompatible change)
     * Pass storage instance in metadata to all controllers
     * Move message status tags from method names to arguments

--- a/lib/voicemail/call_controllers/mailbox_main_menu_controller.rb
+++ b/lib/voicemail/call_controllers/mailbox_main_menu_controller.rb
@@ -46,7 +46,7 @@ module Voicemail
     end
 
     def listen_to_new_messages
-      invoke MailboxMessagesController, metadata
+      invoke MailboxMessagesController, metadata.merge(new_or_saved: :new)
     end
 
     def listen_to_saved_messages

--- a/spec/voicemail/call_controllers/mailbox_main_menu_controller_spec.rb
+++ b/spec/voicemail/call_controllers/mailbox_main_menu_controller_spec.rb
@@ -32,7 +32,7 @@ describe Voicemail::MailboxMainMenuController do
 
   describe "#listen_to_new_messages" do
     it "invokes MailboxMessagesController" do
-      should_invoke Voicemail::MailboxMessagesController, mailbox: mailbox[:id], storage: storage_instance
+      should_invoke Voicemail::MailboxMessagesController, mailbox: mailbox[:id], new_or_saved: :new, storage: storage_instance
       controller.listen_to_new_messages
     end
   end


### PR DESCRIPTION
If this is left empty, and someone listens to all their saved messages, the metadata retains the previous `:saved` state and only new messages can't be successfuly revisited.
