### PR TITLE
Voicemail messages shouldn't save on timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * BUG - Remove redundant `save_recording` method from `recording_menu` timeout and failure conditions to prevent voicemails from being saved multiple times.
   * BUG - Listening to new messages needs to set the `new_or_saved` metadata. Otherwise, after visiting saved messages, the status is always `:saved`
   * FEATURE - Refactor voicemail storage (backward incompatible change)
     * Pass storage instance in metadata to all controllers

--- a/lib/voicemail/call_controllers/voicemail_controller.rb
+++ b/lib/voicemail/call_controllers/voicemail_controller.rb
@@ -1,7 +1,7 @@
 module Voicemail
   class VoicemailController < ApplicationController
 
-    attr_accessor :recording
+    attr_accessor :recording, :recording_saved
 
     def run
       answer if config.when_to_answer == :before_greeting
@@ -40,7 +40,7 @@ module Voicemail
     end
 
     def record_message
-      ensure_message_saved_if_hangup
+      ensure_message_saved_on_hangup
 
       @recording = record record_options
 
@@ -53,22 +53,22 @@ module Voicemail
         match('2') { record_message }
 
         invalid {  }
-        timeout { save_recording }
-        failure { save_recording }
+        timeout {  }
+        failure {  }
       end
     end
 
   private
 
-    def ensure_message_saved_if_hangup
+    def ensure_message_saved_on_hangup
       call.on_end do
-        save_recording if recording && !@saved
+        save_recording if recording && !recording_saved
       end
     end
 
     def save_recording
       storage.save_recording mailbox[:id], :new, call.from, recording.complete_event.recording
-      @saved = true
+      @recording_saved = true
     end
 
     def recording_url


### PR DESCRIPTION
Currently if a caller reaches the `recording_menu` and then times out, the `save_recording` method is fired once _per_ loop. 

This both defeats the purpose of giving them a timeout - since the voicemail is now saved anyway! - and results in duplicate voicemails being saved until the call is hungup or it fails after the third retry (at which point, a fourth voicemail is saved from `failure`). 

A frequent cause of this condition, at least in wireless, is accidental pocket dialing.
